### PR TITLE
Fix bug: a request from unknown browsers change global setAllHeaders setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,7 @@ module.exports = function csp(options) {
 
     var browser = platform.parse(req.headers['user-agent']);
     var version = parseFloat(browser.version);
+    var unknownBrowser = false;
 
     DIRECTIVES.forEach(function (directive) {
 
@@ -194,7 +195,7 @@ module.exports = function csp(options) {
       break;
 
       default:
-        setAllHeaders = true;
+        unknownBrowser = true;
 
     }
 
@@ -208,7 +209,7 @@ module.exports = function csp(options) {
       }
     }).join(';');
 
-    if (setAllHeaders) {
+    if (setAllHeaders || unknownBrowser) {
       headers = ALL_HEADERS;
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -127,7 +127,19 @@ describe('csp middleware', function () {
     .expect('X-Content-Security-Policy', /default-src 'self' domain.com/)
     .expect('Content-Security-Policy', /default-src 'self' domain.com/)
     .expect('X-WebKit-CSP', /default-src 'self' domain.com/)
-    .end(done);
+    .end(function(err) {
+      if (err) {
+        return done(err);
+      }
+      // unknown browser doesn't affect the next request
+      request(app).get('/').set('User-Agent', AGENTS['Chrome 27'].string)
+      .expect('Content-Security-Policy', /default-src 'self' domain.com/)
+      .expect(function(res) {
+        assert(!res.get('X-Content-Security-Policy'));
+        assert(!res.get('X-WebKit-CSP'));
+      })
+      .end(done);
+    });
   });
 
   it('sets the report-only headers', function (done) {


### PR DESCRIPTION
After receiving a request from unknown browsers, all headers are send to any browser.
