### PR TITLE
Add support for frame-ancestors directive

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var DIRECTIVES = [
   "img-src",
   "media-src",
   "frame-src",
+  "frame-ancestors",
   "font-src",
   "connect-src",
   "style-src",
@@ -153,6 +154,12 @@ module.exports = function csp(options) {
           headers.push("X-WebKit-CSP");
         } else if (version >= 25) {
           headers.push("Content-Security-Policy");
+        }
+
+        // older versions of Chrome don't support frame-ancestors,
+        // and will crash the tab if we send the header
+        if (version <= 40 && policy['frame-ancestors']) {
+          delete policy['frame-ancestors'];
         }
         break;
 

--- a/test/index.js
+++ b/test/index.js
@@ -52,10 +52,16 @@ describe("csp middleware", function () {
     },
     "Chrome 24": {
       string: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.60 Safari/537.17",
-      header: "X-WebKit-CSP"
+      header: "X-WebKit-CSP",
+      noFrameAncestors: true
     },
     "Chrome 27": {
       string: "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.93 Safari/537.36",
+      header: "Content-Security-Policy",
+      noFrameAncestors: true
+    },
+    "Chrome 41": {
+      string: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2252.2 Safari/537.36",
       header: "Content-Security-Policy"
     },
     "Opera 15": {
@@ -194,7 +200,7 @@ describe("csp middleware", function () {
     it("sets the header properly for " + name + " given dashed names", function (done) {
       var app = use(POLICY);
       var header = agent.header;
-      request(app).get("/").set("User-Agent", agent.string)
+      var req = request(app).get("/").set("User-Agent", agent.string)
       .expect(header, /default-src 'self' default.com/)
       .expect(header, /script-src scripts.com/)
       .expect(header, /img-src img.com/)
@@ -203,16 +209,19 @@ describe("csp middleware", function () {
       .expect(header, /object-src object.com/)
       .expect(header, /media-src media.com/)
       .expect(header, /frame-src frame.com/)
-      .expect(header, /frame-ancestors frameancestor.com/)
       .expect(header, /sandbox allow-forms allow-scripts/)
-      .expect(header, /report-uri \/report-violation/)
-      .end(done);
+      .expect(header, /report-uri \/report-violation/);
+
+      if (!agent.noFrameAncestors) {
+          req.expect(header, /frame-ancestors frameancestor.com/)
+      }
+      req.end(done);
     });
 
     it("sets the header properly for " + name + " given camelCased names", function (done) {
       var app = use(CAMELCASE_POLICY);
       var header = agent.header;
-      request(app).get("/").set("User-Agent", agent.string)
+      var req = request(app).get("/").set("User-Agent", agent.string)
       .expect(header, /default-src 'self' default.com/)
       .expect(header, /script-src scripts.com/)
       .expect(header, /img-src img.com/)
@@ -221,10 +230,13 @@ describe("csp middleware", function () {
       .expect(header, /object-src object.com/)
       .expect(header, /media-src media.com/)
       .expect(header, /frame-src frame.com/)
-      .expect(header, /frame-ancestors frameancestor.com/)
       .expect(header, /sandbox allow-forms allow-scripts/)
-      .expect(header, /report-uri \/report-violation/)
-      .end(done);
+      .expect(header, /report-uri \/report-violation/);
+
+      if (!agent.noFrameAncestors) {
+          req.expect(header, /frame-ancestors frameancestor.com/)
+      }
+      req.end(done);
     });
 
   });

--- a/test/index.js
+++ b/test/index.js
@@ -21,6 +21,7 @@ describe("csp middleware", function () {
     "object-src": ["object.com"],
     "media-src": ["media.com"],
     "frame-src": ["frame.com"],
+    "frame-ancestors": ["frameancestor.com"],
     "sandbox": ["allow-forms", "allow-scripts"],
     "report-uri": "/report-violation"
   };
@@ -35,6 +36,7 @@ describe("csp middleware", function () {
     objectSrc: ["object.com"],
     mediaSrc: ["media.com"],
     frameSrc: ["frame.com"],
+    frameAncestors: ["frameancestor.com"],
     sandbox: ["allow-forms", "allow-scripts"],
     reportUri: "/report-violation"
   };
@@ -201,6 +203,7 @@ describe("csp middleware", function () {
       .expect(header, /object-src object.com/)
       .expect(header, /media-src media.com/)
       .expect(header, /frame-src frame.com/)
+      .expect(header, /frame-ancestors frameancestor.com/)
       .expect(header, /sandbox allow-forms allow-scripts/)
       .expect(header, /report-uri \/report-violation/)
       .end(done);
@@ -218,6 +221,7 @@ describe("csp middleware", function () {
       .expect(header, /object-src object.com/)
       .expect(header, /media-src media.com/)
       .expect(header, /frame-src frame.com/)
+      .expect(header, /frame-ancestors frameancestor.com/)
       .expect(header, /sandbox allow-forms allow-scripts/)
       .expect(header, /report-uri \/report-violation/)
       .end(done);
@@ -240,6 +244,7 @@ describe("csp middleware", function () {
     .expect(header, /object-src object.com/)
     .expect(header, /media-src media.com/)
     .expect(header, /frame-src frame.com/)
+    .expect(header, /frame-ancestors frameancestor.com/)
     .expect(header, /sandbox allow-forms allow-scripts/)
     .expect(header, /report-uri \/report-violation/)
     .end(done);


### PR DESCRIPTION
The ```frame-ancestors``` directive will be a more capable replacement for ```X-Frame-Options``` when it is supported across browsers. Already it is supported in Firefox 4+ and in Chrome Canary. This PR lets Helmet set that header.