### PR TITLE
Remove usage of lodash from lib code

### DIFF
--- a/lib/browser-handlers.js
+++ b/lib/browser-handlers.js
@@ -1,9 +1,21 @@
-var _ = require("lodash");
+var util = require('core-util-is');
 var config = require("./config");
 
 var SET_NOTHING = { headers: [] };
 
 var handlers = {};
+
+function shallowCopy (obj) {
+  var n = {};
+  Object.keys(obj).forEach(function (key) {
+    if (util.isArray(obj[key])) {
+      n[key] = obj[key].slice();
+    } else {
+      n[key] = obj[key];
+    }
+  });
+  return n;
+}
 
 handlers.default = function() {
   return { headers: config.allHeaders };
@@ -28,8 +40,8 @@ handlers.Firefox = function(browser, directives) {
     return { headers: ["Content-Security-Policy"] };
   } else if ((version >= 4) && (version < 23)) {
 
-    var policy = _.cloneDeep(directives);
-
+    policy = shallowCopy(directives);
+    
     policy["default-src"] = policy["default-src"] || ["*"];
 
     Object.keys(policy).forEach(function (key) {
@@ -119,10 +131,10 @@ handlers["Chrome Mobile"] = function(browser, directives) {
     var result = { headers: ["Content-Security-Policy"] };
     var connect = directives["connect-src"];
     if (!connect) {
-      result.directives = _.cloneDeep(directives);
+      result.directives = shallowCopy(directives);
       result.directives["connect-src"] = ["'self'"];
     } else if (connect.indexOf("'self'") === -1) {
-      result.directives = _.cloneDeep(directives);
+      result.directives = shallowCopy(directives);
       result.directives["connect-src"].push("'self'");
     }
     return result;

--- a/lib/make-policy-string.js
+++ b/lib/make-policy-string.js
@@ -1,7 +1,6 @@
-var _ = require("lodash");
 
 module.exports = function makePolicyString(directives) {
-  return _.map(directives, function(value, key) {
-    return [key].concat(value).join(" ");
+  return Object.keys(directives).map(function (value) {
+  	return [value].concat(directives[value]).join(" ");
   }).join(";");
 };

--- a/lib/parse-directives.js
+++ b/lib/parse-directives.js
@@ -1,4 +1,4 @@
-var _ = require("lodash");
+var util = require('core-util-is');
 
 var config = require("./config");
 
@@ -8,7 +8,7 @@ function parseValue(key, value) {
 
   if (key === "sandbox" && value === true) {
     result = [];
-  } else if (_.isString(value)) {
+  } else if (util.isString(value)) {
     result = value.split(/\s/g);
   } else if (!Array.isArray(value)) {
     throw new Error("Invalid directive: " + key + " " + value + ".");

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
   },
   "dependencies": {
     "camelize": "1.0.0",
-    "lodash": "3.5.0",
-    "platform": "1.3.0"
+    "platform": "1.3.0",
+    "core-util-is": "1.0.1"
   },
   "devDependencies": {
     "connect": "^3.3.5",
+    "lodash": "3.5.0",
     "mocha": "^2.2.1",
     "supertest": "^0.15.0"
   }


### PR DESCRIPTION
Fixes #12 

This uses the same [core-util-is](https://www.npmjs.com/package/core-util-is) module as used in https://github.com/helmetjs/hsts/pull/1 for checking types. When not supporting pre node.js 0.12.x versions any more, this module can be removed and one can only rely on the native `util` in node.js / iojs.

There was one usage of lodash `.map` function which now are replaced with plain higher order Array functions.

Then, there was a lodash deep copy of objects. From what I could see this copy function only copy the config object which is pretty flat and holds only `String` and `Array` values. I replaced this with a very simple shallow copy function instead. This shallow copy function only copy one level and only handle Arrays as special values. If a deep copy is wanted we could replace this with:

```js
var newObject = JSON.parse(JSON.stringify(originalObject));
```

Lodash are still present as a devDependency since its used in the tests.