### PR TITLE
FIx formatting in example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ app.use(csp({
   mediaSrc: ['media.com'],
   frameSrc: ['frame.com'],
   sandbox: ['allow-forms', 'allow-scripts'],
-  reportUri: '/report-violation', reportOnly: false, // set to true if you only want to report errors setAllHeaders: false, // set to true if you want to set all headers disableAndroid: false, // set to true to disable CSP on Android (can be flaky) safari5: false // set to true if you want to force buggy CSP in Safari 5
+  reportUri: '/report-violation',
+  reportOnly: false, // set to true if you only want to report errors
+  setAllHeaders: false, // set to true if you want to set all headers
+  disableAndroid: false, // set to true to disable CSP on Android (can be flaky)
+  safari5: false // set to true if you want to force buggy CSP in Safari 5
 }));
 ```
 


### PR DESCRIPTION
There were no newlines after the reportUri option anymore.