### PR TITLE
Enable dynamically generated values

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,29 @@ app.post('/report-violation', function (req, res) {
 Not all browsers send CSP violations the same.
 
 *Note*: If you're using a CSRF module like [csurf](https://github.com/expressjs/csurf), you might have problems handling these violations without a valid CSRF token. The fix is to put your CSP report route *above* csurf middleware.
+
+Generating Nonces
+_________________
+
+You can dynamically generating nonces to allow inline `<script>`
+tags to be safely evaluated. Here's a simple example:
+
+```js
+
+var uuid = require('node-uuid');
+
+app.use(csp({
+  scriptSrc: [
+    "'self'",
+    function(req) {
+      var nonce = uuid.v4();
+      req.nonce = nonce;
+      return "'nonce-" + nonce + "'"; // 'nonce-$RANDOM'
+    }
+  ]
+}))
+
+app.use(function(req, res) {
+  res.end('<script nonce="' + req.nonce + '">alert(1 + 1);</script>');
+});
+```

--- a/index.js
+++ b/index.js
@@ -26,7 +26,10 @@ module.exports = function csp(passedOptions) {
 
     var policyString;
     if (headerData.headers.length) {
-      policyString = cspBuilder({ directives: headerData.directives });
+      policyString = cspBuilder({
+        directives: headerData.directives,
+        arguments: [req]
+      });
     }
 
     headerData.headers.forEach(function(header) {


### PR DESCRIPTION
This pull request won't be ready to merge until https://github.com/helmetjs/content-security-policy-builder/pull/1 is merged and I update this pull requests `package.json` to match -- but I thought I'd just open this up for early feedback.

Allows users to dynamically generate certain values (e.g. `nonce-$RANDOM`), without having to do the workaround you provided in #19. I've included an example in the README of how it could be used