### PR TITLE
Fix README issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,20 +71,22 @@ You can dynamically generate nonces to allow inline `<script>` tags to be safely
 var uuid = require('node-uuid')
 
 app.use(function (req, res, next) {
-  req.locals.nonce = uuid.v4()
+  res.locals.nonce = uuid.v4()
   next()
 })
 
 app.use(csp({
-  scriptSrc: [
-    "'self'",
-    function (req) {
-      return "'nonce-" + req.locals.nonce + "'"  // 'nonce-614d9122-d5b0-4760-aecf-3a5d17cf0ac9'
-    }
-  ]
+  directives: {
+    scriptSrc: [
+      "'self'",
+      function (req, res) {
+        return "'nonce-" + res.locals.nonce + "'"  // 'nonce-614d9122-d5b0-4760-aecf-3a5d17cf0ac9'
+      }
+    ]
+  }
 }))
 
 app.use(function (req, res) {
-  res.end('<script nonce="' + req.nonce + '">alert(1 + 1);</script>')
+  res.end('<script nonce="' + res.locals.nonce + '">alert(1 + 1);</script>')
 })
 ```

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function csp (options) {
     var directives = transformDirectivesForBrowser(browser, originalDirectives)
 
     if (directivesAreDynamic) {
-      directives = parseDynamicDirectives(directives, [req])
+      directives = parseDynamicDirectives(directives, [req, res])
     }
 
     var policyString = cspBuilder({ directives: directives })

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "platform": "1.3.0"
   },
   "devDependencies": {
-    "connect": "^3.3.5",
     "content-security-policy-parser": "^0.1.0",
+    "express": "^4.13.3",
     "lodash": "^3.7.0",
     "mocha": "^2.3.4",
     "standard": "^5.4.1",

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@ var csp = require('..')
 
 var _ = require('lodash')
 var parseCsp = require('content-security-policy-parser')
-var connect = require('connect')
+var express = require('express')
 var request = require('supertest')
 var assert = require('assert')
 var AGENTS = require('./browser-data')
@@ -10,8 +10,8 @@ var AGENTS = require('./browser-data')
 var POLICY = {
   defaultSrc: ["'self'"],
   'script-src': ['scripts.biz'],
-  styleSrc: ['styles.biz', function (req) {
-    return req.nonce
+  styleSrc: ['styles.biz', function (req, res) {
+    return res.locals.nonce
   }],
   objectSrc: [],
   imgSrc: 'data:'
@@ -27,9 +27,9 @@ var EXPECTED_POLICY = {
 
 describe('csp middleware', function () {
   function use (options) {
-    var result = connect()
+    var result = express()
     result.use(function (req, res, next) {
-      req.nonce = 'abc123'
+      res.locals.nonce = 'abc123'
       next()
     })
     result.use(csp(options))


### PR DESCRIPTION
I noticed that the example for generating nonces had a few issues that new users might find confusing. The first issue was just that it was using the old options format without a `directives` property, the second issue was that it was using `req.locals` instead of [`res.locals`](http://expressjs.com/en/api.html#res.locals).

I also updated the tests to use express instead of connect which doesn't have a `res.locals` property because I thought'd it'd be nice to test the exact scenario shown in the example, but I'm happy to undo the changes to the test if you don't care for them.