### PR TITLE
Add opt-out for UA parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ app.use(csp({
   // X-WebKit-CSP, and X-Content-Security-Policy.
   setAllHeaders: false,
 
+  // Set to false to never set X- headers regardless of user agent
+  setLegacyHeaders: true,
+
   // Set to true if you want to disable CSP on Android where it can be buggy.
   disableAndroid: false
 }))
@@ -92,3 +95,21 @@ app.use(function (req, res) {
   res.end('<script nonce="' + res.locals.nonce + '">alert(1 + 1);</script>')
 })
 ```
+
+Using CSP with a CDN
+--------------------
+
+The default behavior of CSP is generate headers tailored for the browser that's requesting your page. If you have a CDN in front of your application, the CDN may cache the wrong headers, rendering your CSP useless.
+
+Legacy headers are set on the following browsers:
+
+| Name    | Version | Released |
+|---------|---------|----------|
+| IE      | < 12    | 2015     |
+| Firefox | < 23    | 2013     |
+| Chrome  | < 25    | 2013     |
+| Safari  | < 7     | 2013     |
+
+If you want your CSP to support these browsers, use the `setAllHeaders: true` option. If you don't care about older browsers and want to save some bits over the wire and cycles on your servers, use the `setLegacyHeaders: false` option.
+
+

--- a/lib/get-standard-browser.js
+++ b/lib/get-standard-browser.js
@@ -1,0 +1,8 @@
+var CSP_HEADER = require('./headers').CSP
+
+module.exports = function getStandardBrowser (userAgent, directives) {
+  return {
+    headerKeys: [CSP_HEADER],
+    directives: directives
+  }
+}

--- a/lib/get-ua-based-browser.js
+++ b/lib/get-ua-based-browser.js
@@ -1,0 +1,30 @@
+var ALL_HEADERS = require('./all-headers')
+var platform = require('platform')
+var getHeaderKeysForBrowser = require('./get-header-keys-for-browser')
+var transformDirectivesForBrowser = require('./transform-directives-for-browser')
+
+module.exports = function getUABasedBrowser (userAgent, originalDirectives, options) {
+  var browser
+  if (userAgent) {
+    browser = platform.parse(userAgent)
+  } else {
+    browser = {}
+  }
+
+  var headerKeys
+  if (options.setAllHeaders || !userAgent) {
+    headerKeys = ALL_HEADERS
+  } else {
+    headerKeys = getHeaderKeysForBrowser(browser, options)
+  }
+
+  var directives
+  if (headerKeys.length) {
+    directives = transformDirectivesForBrowser(browser, originalDirectives)
+  }
+
+  return {
+    headerKeys: headerKeys,
+    directives: directives
+  }
+}

--- a/lib/headers.js
+++ b/lib/headers.js
@@ -1,0 +1,3 @@
+exports.CSP = 'Content-Security-Policy'
+exports.X = 'X-Content-Security-Policy'
+exports.WEBKIT = 'X-WebKit-CSP'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "helmet-csp",
   "author": "Adam Baldwin <baldwin@andyet.net> (http://andyet.net/team/baldwin)",
   "contributors": [
-    "Evan Hahn <me@evanhahn.com> (http://evanhahn.com)"
+    "Evan Hahn <me@evanhahn.com> (http://evanhahn.com)",
+    "Ryan Cannon <ryan@ryancannon.com> (https://ryancannon.com)"
   ],
   "description": "Content Security Policy middleware.",
   "version": "1.0.3",
@@ -39,6 +40,7 @@
     "content-security-policy-parser": "^0.1.0",
     "express": "^4.13.3",
     "lodash": "^3.7.0",
+    "lodash.pickby": "^4.2.0",
     "mocha": "^2.3.4",
     "standard": "^5.4.1",
     "supertest": "^1.1.0"
@@ -46,6 +48,7 @@
   "standard": {
     "globals": [
       "describe",
+      "before",
       "beforeEach",
       "it"
     ]

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 var csp = require('..')
 
 var _ = require('lodash')
-var pickBy = require('lodash.pickBy')
+var pickBy = require('lodash.pickby')
 var parseCsp = require('content-security-policy-parser')
 var express = require('express')
 var request = require('supertest')

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 var csp = require('..')
 
 var _ = require('lodash')
+var pickBy = require('lodash.pickBy')
 var parseCsp = require('content-security-policy-parser')
 var express = require('express')
 var request = require('supertest')
@@ -340,6 +341,42 @@ describe('csp middleware', function () {
       request(app).get('/').set('User-Agent', iosChrome.string)
       .expect(iosChrome.header, "connect-src somedomain.com 'self'")
       .end(done)
+    })
+  })
+
+  describe('setLegacyHeaders: false', function () {
+    var app
+
+    before(function () {
+      app = use({
+        setLegacyHeaders: false,
+        directives: {
+          'default-src': ["'self'", 'domain.com']
+        }
+      })
+    })
+
+    var specialAgents = pickBy(AGENTS, function (agent) {
+      return agent.header !== 'Content-Security-Policy'
+    })
+    _.each(specialAgents, function (agent, name) {
+      it('omits legacy headers if told to for ' + name, function (done) {
+        request(app).get('/').set('User-Agent', agent.string)
+          .expect('Content-Security-Policy', "default-src 'self' domain.com")
+          .end(done)
+      })
+    })
+
+    it('throws an error with conflicting options', function () {
+      assert.throws(function () {
+        csp({
+          setAllHeaders: true,
+          setLegacyHeaders: false,
+          directives: {
+            defaultSrc: ["'self'", 'domain.com']
+          }
+        })
+      }, Error)
     })
   })
 })


### PR DESCRIPTION
Currently the only option for caching responses from CSP are to use
`setAllHeaders: true`, lest a browser-specific CSP gets cached for the wrong
UA. This PR adds a new option, `setLegacyHeaders`, which will skip UA parsing
if defined and falsey.

This adds a testing dependency on `lodash.pickby`, which we can remove by
upgrading lodash to the latest version.

Lastly, I added a constants file for header names in `lib/headers.js`. In
order to minimize change, I didn't refactor existing files to use it, but it
might help cut down on duplication and human error potential to use it in
other places.

Fixes #32.