### PR TITLE
Allow 'reportOnly' option to be set dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ app.use(csp({
     objectSrc: [], // An empty array allows nothing through
   },
 
-  // Set to true if you only want browsers to report errors, not block them
+  // Set to true if you only want browsers to report errors, not block them.
+  // You may also set this to a function(req, res) in order to decide dynamically
+  // whether to use reportOnly mode, e.g., to allow for a dynamic kill switch.
   reportOnly: false,
 
   // Set to true if you want to blindly set all headers: Content-Security-Policy,

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 var camelize = require('camelize')
 var cspBuilder = require('content-security-policy-builder')
+var isFunction = require('lodash.isfunction')
 var platform = require('platform')
 var containsFunction = require('./lib/contains-function')
 var getHeaderKeysForBrowser = require('./lib/get-header-keys-for-browser')
 var transformDirectivesForBrowser = require('./lib/transform-directives-for-browser')
 var parseDynamicDirectives = require('./lib/parse-dynamic-directives')
 var ALL_HEADERS = require('./lib/all-headers')
-var isFunction = require('lodash.isFunction')
 
 module.exports = function csp (options) {
   options = options || {}


### PR DESCRIPTION
I have found it helpful to have a dynamic kill switch for CSP that turns it from enforcing to report-only in case of an emergency, especially during the initial roll-out.  This feature avoids having to do an emergency deploy in order to switch back to report-only mode.

Let me know whether you'd be open to this in principle, and I'd be happy to make any changes you request in order to get this landed.

Thanks.