### PR TITLE
Add frame-src directive to whitelist

### DIFF
--- a/lib/config.json
+++ b/lib/config.json
@@ -7,6 +7,7 @@
     "font-src": { "type": "sourceList" },
     "form-action": { "type": "sourceList" },
     "frame-ancestors": { "type": "sourceList" },
+    "frame-src": { "type": "sourceList" },
     "img-src": { "type": "sourceList" },
     "media-src": { "type": "sourceList" },
     "object-src": { "type": "sourceList" },


### PR DESCRIPTION
`frame-src` wasn't whitelisted, which it should be.

Closes #53.