### PR TITLE
s.getParser was broken because of import * as bowser from 'bowser';

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import camelize from 'camelize';
 import cspBuilder from 'content-security-policy-builder';
-import * as Bowser from 'bowser';
+import Bowser from 'bowser';
 import { IncomingMessage, ServerResponse } from 'http';
 
 import isFunction from './lib/is-function';


### PR DESCRIPTION
I had the dreaded error:

```
s.getParser is not a function
```
On investigation, it was because `bowser` was coming in as a `*` import and `esModuleInterop` is set to true in `tsconfig.json` which negates the need to use the `import *` import.

So my PR changes it to:

```
import bower from 'bowser'`
```

This will fix the problem.

